### PR TITLE
[BASKET-4363] Update java-dogstatsd-client to 4.2.0

### DIFF
--- a/dropwizard-metrics-datadog/pom.xml
+++ b/dropwizard-metrics-datadog/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>metrics-datadog-parent</artifactId>
         <groupId>io.github.singularity-sg</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/dropwizard-metrics-datadog/pom.xml
+++ b/dropwizard-metrics-datadog/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>metrics-datadog-parent</artifactId>
         <groupId>io.github.singularity-sg</groupId>
-        <version>1.0.1</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/metrics-datadog/pom.xml
+++ b/metrics-datadog/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.singularity-sg</groupId>
         <artifactId>metrics-datadog-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/metrics-datadog/pom.xml
+++ b/metrics-datadog/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.singularity-sg</groupId>
         <artifactId>metrics-datadog-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -102,7 +102,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -119,8 +119,8 @@
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>2.28.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <properties>
         <metrics.version>4.0.2</metrics.version>
         <jackson.version>2.9.6</jackson.version>
-        <dropwizard.version>1.3.5</dropwizard.version>
+        <dropwizard.version>2.0.35</dropwizard.version>
         <junitJupiter.version>5.5.2</junitJupiter.version>
     </properties>
 
@@ -176,7 +176,7 @@
             <dependency>
                 <groupId>com.datadoghq</groupId>
                 <artifactId>java-dogstatsd-client</artifactId>
-                <version>2.8.1</version>
+                <version>4.2.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.singularity-sg</groupId>
     <artifactId>metrics-datadog-parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
     <name>Datadog Metrics Parent</name>
     <url>https://github.com/singularity-sg/metrics-datadog</url>


### PR DESCRIPTION
Upgrade java-dogstatsd-client to 4.2.0

ref: https://github.com/viafoura/metrics-datadog/pull/7
JIRA: https://zendesk.atlassian.net/browse/BASKET-4363

currently `1.1.0` put to zendesk artifactory manually by @singularity-sg 